### PR TITLE
Initial travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,5 +31,6 @@ install:
 
 script:
 # Build the package, its tests, and its docs and run the tests
-- ./tests/verify/verify.sh
+- cd tests/verify/
+- ./verify.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_install:
 
 install:
 # Build dependencies
+- stack --no-terminal --install-ghc
 - ./install.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_install:
 
 install:
 # Build dependencies
-- stack --no-terminal --install-ghc
+- stack --no-terminal --install-ghc test --only-dependencies
 - ./install.sh
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 install:
 # Build dependencies
 - stack --no-terminal --install-ghc test --only-dependencies
-- ./install.sh
+- travis_wait ./install.sh
 
 script:
 # Build the package, its tests, and its docs and run the tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+# Use new container infrastructure to enable caching
+sudo: false
+
+language: java
+
+jdk:
+  - oraclejdk8
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.ghc
+  - $HOME/.cabal
+  - $HOME/.stack
+
+# Ensure necessary system libraries are present
+addons:
+  apt:
+    packages:
+      - libgmp-dev
+
+before_install:
+# Download and unpack the stack executable
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+
+install:
+# Build dependencies
+- ./install.sh
+
+script:
+# Build the package, its tests, and its docs and run the tests
+- ./tests/verify/verify.sh
+

--- a/tests/verify/verify.sh
+++ b/tests/verify/verify.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+set -e
+
 # (Re)build the Verify.java script and copy the class file here
 javac ../../utils/class-verifier/Verify.java
 cp ../../utils/class-verifier/Verify.class .


### PR DESCRIPTION
Creates a oracle jdk 8 environment along with stack and right now it just runs `verify.sh`. We can expand on this further. Also I have added `set -e` on `verify.sh`.